### PR TITLE
Add raw/primary and data dictionary pages

### DIFF
--- a/docs/guides/.pages.yml
+++ b/docs/guides/.pages.yml
@@ -1,5 +1,7 @@
 title: Getting Started
 arrange:
   - 1_getting_started.md
+  - 4_data_dictionary.md'
+  - 5_raw_and_primary.md
   - 2_advanced_practices.md
   - 3_dev_guide.md

--- a/docs/guides/.pages.yml
+++ b/docs/guides/.pages.yml
@@ -1,7 +1,7 @@
 title: Getting Started
 arrange:
   - 1_getting_started.md
-  - 4_data_dictionary.md'
+  - 4_data_dictionary.md
   - 5_raw_and_primary.md
   - 2_advanced_practices.md
   - 3_dev_guide.md

--- a/docs/guides/1_getting_started.md
+++ b/docs/guides/1_getting_started.md
@@ -67,7 +67,9 @@ You will need to select one directory (folder) for the study whose data you are 
 
 - Within the data directory, you can create any folder structure that suits your needs. Psych-DS will detect all files inside the `data/` folder and run them through validation. 
 
-- There is one exception - the `data/raw/` directory. If the earliest digital form of your data is *not* going to be formatted in CSV (see next step) - you can put them into this folder, and Psych-DS will know to ignore them during validation. 
+- There is one exception - the `data/raw/` directory. If the earliest digital form of your data is *not* going to be formatted in CSV (see next step) - you can put them into this folder, and Psych-DS will know to ignore them during validation. For more details on raw and primary data, visit [this page](./5_raw_and_primary.md).
+
+    
 
 After completing this step, your (empty) directory structure might look like this: 
 

--- a/docs/guides/4_data_dictionary.md
+++ b/docs/guides/4_data_dictionary.md
@@ -1,0 +1,71 @@
+# Creating a data dictionary
+
+One of the most important functions of metadata in Psych-DS is to provide descriptions of the various variables that appear across your data files. Some researchers may be familiar with the process of creating "data dictionaries" for their studies, which are separate documents that contain important contextual information about the elements of a dataset. In Psych-DS, the `variableMeasured` field of our metadata file is where we provide this information. 
+
+!!! info "Without proper documentation of variables"
+    - Column names are ambiguous. For instance, the column "rt" could mean "reaction time", "reading time", or "room temperature"
+    - Units of measurement may be unclear (milliseconds vs seconds, Celsius vs Fahrenheit)
+    - Categorical variables may use numeric codes without explanation (1=agree, 2=neutral, etc.)
+    - The full range of possible values may be unknown
+
+## The variableMeasured property in Psych-DS
+
+In Psych-DS, the `variableMeasured` property in your dataset_description.json file serves as your data dictionary. At minimum, it must contain an array listing every column header that appears in any of your CSV files:
+
+```json
+{
+    "@context": "http://schema.org/",
+    "@type": "Dataset",
+    "name": "Example Study",
+    "description": "A simple example dataset",
+    "variableMeasured": ["participant_id", "condition", "rt", "accuracy"]
+}
+```
+
+However, this minimal approach, while valid, doesn't really provide us with the information we need.
+
+## Better variable documentation
+
+Psych-DS uses metadata fields from the `Schema.org` ontology. We use the `Dataset` type for the overarching metadata object, and this type can take certain parameters as listed [here](https://schema.org/Dataset). One of these is `variableMeasured`, which expects to take an array of `PropertyValue` objects as its value. We can use these `PropertyValue` objects to store necessary contextual information for each variable.
+
+```json
+{
+    "@context": "http://schema.org/",
+    "@type": "Dataset",
+    "name": "Example Study",
+    "description": "A simple example dataset",
+    "variableMeasured": [
+        {
+            "@type": "PropertyValue",
+            "name": "rt",
+            "description": "Response time from stimulus onset to button press",
+            "unitText": "milliseconds",
+            "minValue": 0,
+            "maxValue": 2000
+        },
+        {
+            "@type": "PropertyValue",
+            "name": "condition",
+            "description": "Experimental condition", //Here we could provide detailed descriptions of each condition
+            "valuePattern": "control|treatment_a|treatment_b"
+        }
+    ]
+}
+```
+
+## Recommended PropertyValue fields
+
+When documenting your variables, consider including these Schema.org PropertyValue fields:
+
+- `name`: The exact column header as it appears in your CSV files (required)
+- `description`: A clear explanation of what the variable represents
+- `unitText`: The unit of measurement, if applicable
+- `minValue` and `maxValue`: The allowed range of values
+- `valuePattern`: For categorical variables, the possible values (can use regex patterns)
+- any of the [other fields that `PropertyValue` objects can take](https://schema.org/PropertyValue)
+
+!!! tip "Best practices"
+    - Write descriptions that would make sense to someone outside your lab. If there's something worth knowing about what this variable represents, put it here.
+    - Include relevant context about how variables were measured or calculated, including variables that are dependent on other variables, e.g. standard deviations.
+    - Document any codes or abbreviations used in the data
+    - Note any special values (e.g., "-999 represents missing data")

--- a/docs/guides/5_raw_and_primary.md
+++ b/docs/guides/5_raw_and_primary.md
@@ -1,0 +1,71 @@
+# Raw and primary data
+
+A fundamental principle of Psych-DS is the preservation of the earliest available form of research data. This page explains the distinctions between raw and primary data, and how to handle different data types within the Psych-DS framework.
+
+## Core principles
+
+!!! important "Key Requirements"
+    - The earliest form of data must be preserved
+    - Original data should never be modified
+    - Different versions of the data should be kept separate
+    - All transformations should be documented
+
+## Understanding raw vs primary data
+
+### Raw data
+
+Raw data refers to the very first form in which data exists, regardless of format. This could be:
+
+- Paper questionnaires
+- Audio/video recordings
+- Device output files
+- Hand-written notes
+- Original Excel workbooks
+- Survey software exports
+
+### Primary data
+
+Primary data refers to the first *digital* form of the data. As defined by the German Psychological Society, this distinction becomes important when raw data begins in a non-digital format.
+
+!!! example "Raw vs Primary Data Examples"
+    **Scenario 1: Paper-based collection**
+
+    - Raw Data: Physical paper questionnaires
+    - Primary Data: Scanned PDFs or spreadsheet with transcribed responses
+    
+    **Scenario 2: Digital Collection**
+
+    - Raw Data: Survey software export file
+    - Primary Data: Same file (raw and primary are identical)
+    
+    **Scenario 3: Behavioral Observation**
+
+    - Raw Data: Video recordings of participant behavior
+    - Primary Data: Spreadsheet of coded behaviors from videos
+
+## Data organization in Psych-DS
+
+### The `data/` directory
+
+Your Psych-DS `data/` directory should contain:
+
+1. Primary data (or the earliest version available)
+2. Any Psych-DS compliant versions of that data
+3. All subsequent processed/transformed versions
+
+### The `data/raw/` subdirectory
+
+If your primary data is not in CSV format, store it in the `data/raw/` subdirectory. This tells the Psych-DS validator to ignore these files while still preserving them as part of your dataset.
+
+!!! tip "Directory structure example"
+    ```
+    my-study/
+        data/
+            raw/
+                original-survey-responses.xlsx
+                participant-videos/
+                    participant001.mp4
+                    participant002.mp4
+            participant-001_data.csv
+            participant-002_data.csv
+    ```

--- a/docs/guides/5_raw_and_primary.md
+++ b/docs/guides/5_raw_and_primary.md
@@ -25,7 +25,7 @@ Raw data refers to the very first form in which data exists, regardless of forma
 
 ### Primary data
 
-Primary data refers to the first *digital* form of the data. As defined by the German Psychological Society, this distinction becomes important when raw data begins in a non-digital format.
+Primary data refers to the first *digital* form of the data. This distinction becomes important when raw data begins in a non-digital format.
 
 !!! example "Raw vs Primary Data Examples"
     **Scenario 1: Paper-based collection**


### PR DESCRIPTION
Added pages for using variableMeasured to create data dictionaries and defining raw/primary data. This PR closes #12 and #11. I wrote out a "guiding principles" section as mentioned in the issue originally, which was intended to deprecate the below section of the original spec doc, but it just felt very internally orientated and more like an introduction to a grant than something that would be on the front page of our docs. Let me know if you disagree

Guiding Principles:

(1) Usability. The specification is designed to be both machine- and human-readable, and the primary target use case for Psych-DS is a dataset that is potentially generated and handled by a single researcher who may be using an arbitrary combination of manual and automatic means for data acquisition and analysis. This means that the bar for introducing new complexity is relatively high, and contributors should carefully consider whether the proposed extensions justify the additional cognitive overhead or manual labor that might be required to comply with the specification. For very large projects (in psychology and other disciplines), it’s often necessary and appropriate to consult with libraries and archiving organizations to prepare a dataset for archiving after the fact, but as researchers increasingly share their own datasets, they need to be able to manage the dataset preparation on their own, given appropriate software tools & support. One very helpful way to achieve this aim is to plan for sharing/archiving from the beginning of a project; Psych-DS is designed to be a format that can be used at any point in the research workflow.

(2) Content agnosticism. A key challenge for Psych-DS is that (because up until recently, much of this data could be processed entirely ‘by hand’) many researchers do not currently adhere to a single standard during their research career, within their own labs and collaborations, much less agree on practices across subfields. Thus, (at least for v1.0), Psych-DS focuses on establishing machine-readable conventions and metadata for describing datasets: how datasets are structured, rather than on what datasets mean. The specification lays out directory structure, file naming, and metadata representation conventions, but is very light on controlled vocabulary referring to variables represented in the dataset.

(3) Privacy awareness. When considering sharing a dataset, researchers are usually balancing the need to protect participants’ personal information with the significant scientific benefits of openly shared, [FAIR](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4792175/) datasets [(Brakewood & Poldrack, 2013)](https://paperpile.com/c/CAogSY/OSbe). In addition to the difficulty of sharing, and concern that they won’t receive credit for sharing, many social scientists face (or expect to face) legal or ethical barriers in sharing datasets with human data [(Houtkoop et al., 2018; Tenopir et al., 2011)](https://paperpile.com/c/CAogSY/lqLT+FBwC). However, in most cases and most jurisdictions, human data from scientific studies that has been de-identified is shareable [(Klein et al., 2018; Meyer, 2018)](https://paperpile.com/c/CAogSY/00O4+SR5b); what varies is how a dataset is determined to be sufficiently de-identified. This determination is in the hands of the individual researcher: we strongly recommend that researchers determine from the beginning of a project which aspects of their data can be de-identified for possible sharing, and which cannot (and must be protected to the degree required by their institution/locality). 

From the perspective of the data specification, there are two important points to be made regarding privacy. First, the specification is designed to support the use case where a researcher wants to share the format and size of their data, but withhold all or some values in the dataset that reflect personally identifying information (PII). Second, even if researchers plan to only ever use this specification internally, it is still a good practice to identify which parts of the data need to be safeguarded as PII. Thus, the specification is designed to support tagging of individual files or variables as private; software applications that wish to support a researcher in safely sharing datasets can then verify the presence/absence of information the researcher has decided not to share. Note, however, that the spec itself provides no mechanism of enforcement, and users should never rely on the supported privacy tags to appropriately control access.